### PR TITLE
Add firewall scripts for linux hosts + ping playbook

### DIFF
--- a/linux/firewall-argentina.sh
+++ b/linux/firewall-argentina.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get rid of firewalld
+systemctl stop firewalld 2>/dev/null
+systemctl disable firewalld 2>/dev/null
+
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-argentina.sh
+++ b/linux/firewall-argentina.sh
@@ -11,6 +11,10 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow traffic on loopback
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
 # Allow established/related incoming connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 

--- a/linux/firewall-argentina.sh
+++ b/linux/firewall-argentina.sh
@@ -17,5 +17,8 @@ iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 iptables -A INPUT -p tcp --dport 20 -j ACCEPT
 iptables -A INPUT -p tcp --dport 21 -j ACCEPT
 
+# Allow icmp
+iptables -A INPUT -p icmp -j ACCEPT
+
 # Print rules
 iptables -L -v --line-numbers

--- a/linux/firewall-argentina.sh
+++ b/linux/firewall-argentina.sh
@@ -11,6 +11,9 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow established/related incoming connections
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # Set default policy to accept outbound requests
 iptables -P OUTPUT ACCEPT
 

--- a/linux/firewall-argentina.sh
+++ b/linux/firewall-argentina.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Flush existing rules
+iptables -F
+
+# Set default policies to drop incoming/forward requests
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+
+# Set default policy to accept outbound requests
+iptables -P OUTPUT ACCEPT
+
+# Allow ssh
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Allow ftp
+iptables -A INPUT -p tcp --dport 20 -j ACCEPT
+iptables -A INPUT -p tcp --dport 21 -j ACCEPT
+
+# Print rules
+iptables -L -v --line-numbers

--- a/linux/firewall-brazil.sh
+++ b/linux/firewall-brazil.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get rid of firewalld
+systemctl stop firewalld 2>/dev/null
+systemctl disable firewalld 2>/dev/null
+
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-brazil.sh
+++ b/linux/firewall-brazil.sh
@@ -11,6 +11,10 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow traffic on loopback
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
 # Allow established/related incoming connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 

--- a/linux/firewall-brazil.sh
+++ b/linux/firewall-brazil.sh
@@ -13,5 +13,8 @@ iptables -P OUTPUT ACCEPT
 # Allow mysql
 iptables -A INPUT -p tcp --dport 3306 -j ACCEPT
 
+# Allow icmp
+iptables -A INPUT -p icmp -j ACCEPT
+
 # Print rules
 iptables -L -v --line-numbers

--- a/linux/firewall-brazil.sh
+++ b/linux/firewall-brazil.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Flush existing rules
+iptables -F
+
+# Set default policies to drop incoming/forward requests
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+
+# Set default policy to accept outbound requests
+iptables -P OUTPUT ACCEPT
+
+# Allow mysql
+iptables -A INPUT -p tcp --dport 3306 -j ACCEPT
+
+# Print rules
+iptables -L -v --line-numbers

--- a/linux/firewall-brazil.sh
+++ b/linux/firewall-brazil.sh
@@ -11,6 +11,9 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow established/related incoming connections
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # Set default policy to accept outbound requests
 iptables -P OUTPUT ACCEPT
 

--- a/linux/firewall-greenland.sh
+++ b/linux/firewall-greenland.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get rid of firewalld
+systemctl stop firewalld 2>/dev/null
+systemctl disable firewalld 2>/dev/null
+
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-greenland.sh
+++ b/linux/firewall-greenland.sh
@@ -13,5 +13,8 @@ iptables -P OUTPUT ACCEPT
 # Allow ssh
 iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 
+# Allow icmp
+iptables -A INPUT -p icmp -j ACCEPT
+
 # Print rules
 iptables -L -v --line-numbers

--- a/linux/firewall-greenland.sh
+++ b/linux/firewall-greenland.sh
@@ -11,6 +11,10 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow traffic on loopback
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
 # Allow established/related incoming connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 

--- a/linux/firewall-greenland.sh
+++ b/linux/firewall-greenland.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Flush existing rules
+iptables -F
+
+# Set default policies to drop incoming/forward requests
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+
+# Set default policy to accept outbound requests
+iptables -P OUTPUT ACCEPT
+
+# Allow ssh
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Print rules
+iptables -L -v --line-numbers

--- a/linux/firewall-greenland.sh
+++ b/linux/firewall-greenland.sh
@@ -11,6 +11,9 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow established/related incoming connections
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # Set default policy to accept outbound requests
 iptables -P OUTPUT ACCEPT
 

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -17,5 +17,8 @@ iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 iptables -A INPUT -p tcp --dport 443 -j ACCEPT
 
+# Allow icmp
+iptables -A INPUT -p icmp -j ACCEPT
+
 # Print rules
 iptables -L -v --line-numbers

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get rid of firewalld
+systemctl stop firewalld 2>/dev/null
+systemctl disable firewalld 2>/dev/null
+
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Get rid of firewalld
-systemctl stop firewalld 2>/dev/null
-systemctl disable firewalld 2>/dev/null
-
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -11,6 +11,10 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow traffic on loopback
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
 # Allow established/related incoming connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -11,6 +11,9 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow established/related incoming connections
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # Set default policy to accept outbound requests
 iptables -P OUTPUT ACCEPT
 

--- a/linux/firewall-korea.sh
+++ b/linux/firewall-korea.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Flush existing rules
+iptables -F
+
+# Set default policies to drop incoming/forward requests
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+
+# Set default policy to accept outbound requests
+iptables -P OUTPUT ACCEPT
+
+# Allow ssh
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Allow http/https
+iptables -A INPUT -p tcp --dport 80 -j ACCEPT
+iptables -A INPUT -p tcp --dport 443 -j ACCEPT
+
+# Print rules
+iptables -L -v --line-numbers

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Get rid of firewalld
+systemctl stop firewalld 2>/dev/null
+systemctl disable firewalld 2>/dev/null
+
 # Flush existing rules
 iptables -F
 

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Get rid of firewalld
-systemctl stop firewalld 2>/dev/null
-systemctl disable firewalld 2>/dev/null
+systemctl stop ufw 2>/dev/null
+systemctl disable ufw 2>/dev/null
 
 # Flush existing rules
 iptables -F

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Get rid of firewalld
+# Get rid of ufw
 systemctl stop ufw 2>/dev/null
 systemctl disable ufw 2>/dev/null
 

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -13,5 +13,8 @@ iptables -P OUTPUT ACCEPT
 # Allow ssh
 iptables -A INPUT -p tcp --dport 22 -j ACCEPT
 
+# Allow icmp
+iptables -A INPUT -p icmp -j ACCEPT
+
 # Print rules
 iptables -L -v --line-numbers

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -11,6 +11,10 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow traffic on loopback
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+
 # Allow established/related incoming connections
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Flush existing rules
+iptables -F
+
+# Set default policies to drop incoming/forward requests
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+
+# Set default policy to accept outbound requests
+iptables -P OUTPUT ACCEPT
+
+# Allow ssh
+iptables -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Print rules
+iptables -L -v --line-numbers

--- a/linux/firewall-russia.sh
+++ b/linux/firewall-russia.sh
@@ -11,6 +11,9 @@ iptables -F
 iptables -P INPUT DROP
 iptables -P FORWARD DROP
 
+# Allow established/related incoming connections
+iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
 # Set default policy to accept outbound requests
 iptables -P OUTPUT ACCEPT
 

--- a/linux/playbooks/ping.yml
+++ b/linux/playbooks/ping.yml
@@ -1,0 +1,5 @@
+---
+  - name: "Test host connectivity"
+    hosts: all
+    tasks:
+      - action: ping


### PR DESCRIPTION
Adds basic firewall setup scripts for linux hosts + ping playbook. The firewall scripts are pretty basic but they do generally work. they might require some configuration depending on the host.